### PR TITLE
Fix a typo

### DIFF
--- a/src/tseitin/Tseitin_intf.ml
+++ b/src/tseitin/Tseitin_intf.ml
@@ -36,8 +36,7 @@ end
 module type S = sig
   (** CNF conversion
 
-      This modules allows to convert arbitrary boolean formulas
-      into CNF.
+      This modules converts arbitrary boolean formulas into CNF.
   *)
 
   type atom


### PR DESCRIPTION
English doesn't allow “allows to” as a form (it needs to be “allows <object> to” or something like this).

A workaround is to use the phrase "make it possible to”, but in this case, I don't think it was warranted, so I simply used a more direct phrase.