### PR TITLE
Prevent bogus failure if an OR-gate is optimised to nothing

### DIFF
--- a/src/tseitin/Msat_tseitin.ml
+++ b/src/tseitin/Msat_tseitin.ml
@@ -91,7 +91,7 @@ module Make (F : Tseitin_intf.Arg) = struct
     if List.exists ((=) f_true) l' then
       f_true
     else match l' with
-      | [] -> raise Empty_Or
+      | [] -> f_false
       | [a] -> a
       | _ -> Comb (Or, l')
 


### PR DESCRIPTION
Due to optimisation and removal of constants it can happen that a bogus exception is generated

# F.make_xor (F.make_not F.f_true) (F.make_not F.f_true);;
Exception: Msat_tseitin.Make(F).Empty_Or.
Raised at Msat_tseitin.Make.make_or in file "src/tseitin/Msat_tseitin.ml", line 94, characters 14-28
Called from Stdlib__Fun.protect in file "fun.ml", line 33, characters 8-15
Re-raised at Stdlib__Fun.protect in file "fun.ml", line 38, characters 6-52
Called from Topeval.load_lambda in file "toplevel/byte/topeval.ml", line 89, characters 4-150
# 

With my patch this expression will give the correct answer, which is F.f_false
