### PR TITLE
Fix warnings

### DIFF
--- a/dune
+++ b/dune
@@ -13,7 +13,7 @@
     (flags
       :standard
       -warn-error -a
-      -w +a-4-42-44-48-50-58-32-60@8
+      -w +a-4-42-44-48-50-58-32-60-70@8
       -color always
       -safe-string
     )

--- a/dune
+++ b/dune
@@ -1,6 +1,6 @@
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (deps README.md src/core/msat.cma src/sat/msat_sat.cma (source_tree src))
  (locks test)
  (package msat)

--- a/dune
+++ b/dune
@@ -8,3 +8,20 @@
           (run mdx test README.md)
           (diff? README.md README.md.corrected))))
 
+(env
+  (_
+    (flags
+      :standard
+      -warn-error -a
+      -w +a-4-42-44-48-50-58-32-60@8
+      -color always
+      -safe-string
+    )
+    (ocamlopt_flags
+      :standard
+      -O3
+      -bin-annot
+      -unbox-closures -unbox-closures-factor 20
+    )
+  )
+)

--- a/dune-project
+++ b/dune-project
@@ -1,1 +1,1 @@
-(lang dune 1.1)
+(lang dune 3.0)

--- a/msat-bin.opam
+++ b/msat-bin.opam
@@ -11,7 +11,7 @@ build: [
 ]
 depends: [
   "ocaml" { >= "4.03" }
-  "dune" { >= "1.1" }
+  "dune" { >= "3.0" }
   "msat" { = version }
   "containers" { >= "2.8.1" & < "4.0" }
   "camlzip"

--- a/msat.opam
+++ b/msat.opam
@@ -12,7 +12,7 @@ build: [
 ]
 depends: [
   "ocaml" { >= "4.03" }
-  "dune" { >= "1.1" }
+  "dune" { >= "3.0" }
   "iter" { >= "1.2" }
   "containers" {with-test & >= "2.8.1" & < "4.0" }
   "mdx" {with-test}

--- a/src/backend/Coq.mli
+++ b/src/backend/Coq.mli
@@ -33,13 +33,13 @@ module type Arg = sig
 
 end
 
-module Make(S : Msat.S)(A : Arg with type hyp := S.clause
+module Make(S : Msat.S)(_ : Arg with type hyp := S.clause
                                 and type lemma := S.clause
                                 and type assumption := S.clause) : S with type t := S.proof
 (** Base functor to output Coq proofs *)
 
 
-module Simple(S : Msat.S)(A : Arg with type hyp = S.formula list
+module Simple(S : Msat.S)(_ : Arg with type hyp = S.formula list
                                   and type lemma := S.lemma
                                   and type assumption := S.formula) : S with type t := S.proof
 (** Simple functor to output Coq proofs *)

--- a/src/backend/Dedukti.mli
+++ b/src/backend/Dedukti.mli
@@ -24,7 +24,7 @@ end
 
 module Make :
   functor(S : Msat.S) ->
-  functor(A : Arg
+  functor(_ : Arg
           with type formula := S.formula
            and type lemma := S.lemma
            and type proof := S.proof) ->

--- a/src/backend/Dot.mli
+++ b/src/backend/Dot.mli
@@ -54,13 +54,13 @@ module Default(S : Msat.S) : Arg with type atom := S.atom
 (** Provides a reasonnable default to instantiate the [Make] functor, assuming
     the original printing functions are compatible with DOT html labels. *)
 
-module Make(S : Msat.S)(A : Arg with type atom := S.atom
+module Make(S : Msat.S)(_ : Arg with type atom := S.atom
                                 and type hyp := S.clause
                                 and type lemma := S.clause
                                 and type assumption := S.clause) : S with type t := S.proof
 (** Functor for making a module to export proofs to the DOT format. *)
 
-module Simple(S : Msat.S)(A : Arg with type atom := S.formula
+module Simple(S : Msat.S)(_ : Arg with type atom := S.formula
                                   and type hyp = S.formula list
                                   and type lemma := S.lemma
                                   and type assumption = S.formula) : S with type t := S.proof

--- a/src/backend/dune
+++ b/src/backend/dune
@@ -3,8 +3,5 @@
   (public_name msat.backend)
   (synopsis "proof backends for msat")
   (libraries msat)
-  (flags :standard -w +a-4-42-44-48-50-58-32-60@8 -warn-error -27 -color always -safe-string)
-  (ocamlopt_flags :standard -O3 -bin-annot
-                  -unbox-closures -unbox-closures-factor 20)
   )
 

--- a/src/backtrack/dune
+++ b/src/backtrack/dune
@@ -3,9 +3,6 @@
   (name msat_backtrack)
   (public_name msat.backtrack)
   (libraries msat)
+  (flags :standard -open Msat)
   (synopsis "backtrackable data structures for msat")
-  (flags :standard -warn-error -3 -w +a-4-42-44-48-50-58-32-60@8
-         -color always -safe-string -open Msat)
-  (ocamlopt_flags :standard -O3 -bin-annot
-                  -unbox-closures -unbox-closures-factor 20)
   )

--- a/src/core/dune
+++ b/src/core/dune
@@ -4,7 +4,4 @@
   (public_name msat)
   (libraries iter)
   (synopsis "core data structures and algorithms for msat")
-  (flags :standard -warn-error -3 -w +a-4-42-44-48-50-58-32-60@8 -color always -safe-string)
-  (ocamlopt_flags :standard -O3 -bin-annot
-                  -unbox-closures -unbox-closures-factor 20)
   )

--- a/src/main/dune
+++ b/src/main/dune
@@ -5,9 +5,7 @@
   (public_name msat)
   (package msat-bin)
   (libraries containers camlzip msat msat.sat msat.backend)
-  (flags :standard -warn-error -3 -w +a-4-42-44-48-50-58-32-60@8 -color always -safe-string -open Msat)
-  (ocamlopt_flags :standard -O3 -color always
-                  -unbox-closures -unbox-closures-factor 20)
+  (flags :standard -open Msat)
   )
 
 (ocamlyacc (modules Dimacs_parse))

--- a/src/sat/dune
+++ b/src/sat/dune
@@ -4,8 +4,6 @@
   (public_name msat.sat)
   (synopsis "purely boolean interface to Msat")
   (libraries msat)
-  (flags :standard -warn-error -3 -w +a-4-42-44-48-50-58-32-60@8 -color always -safe-string -open Msat)
-  (ocamlopt_flags :standard -O3 -color always
-                  -unbox-closures -unbox-closures-factor 20)
+  (flags :standard -open Msat)
   )
 

--- a/src/sudoku/dune
+++ b/src/sudoku/dune
@@ -3,7 +3,4 @@
   (name sudoku_solve)
   (modes native)
   (libraries msat msat.backtrack iter containers)
-  (flags :standard -warn-error -a -w +a-4-42-44-48-50-58-32-60@8 -color always -safe-string)
-  (ocamlopt_flags :standard -O3 -bin-annot
-                  -unbox-closures -unbox-closures-factor 20)
 )

--- a/src/tseitin/Msat_tseitin.ml
+++ b/src/tseitin/Msat_tseitin.ml
@@ -16,7 +16,6 @@ module type S = Tseitin_intf.S
 
 module Make (F : Tseitin_intf.Arg) = struct
 
-  exception Empty_Or
   type combinator = And | Or | Imp | Not
 
   type atom = F.t

--- a/src/tseitin/dune
+++ b/src/tseitin/dune
@@ -4,8 +4,5 @@
   (public_name msat.tseitin)
   (synopsis "Tseitin transformation for msat")
   (libraries msat)
-  (flags :standard -w +a-4-42-44-48-50-58-32-60@8 -color always -safe-string)
-  (ocamlopt_flags :standard -O3 -bin-annot
-                  -unbox-closures -unbox-closures-factor 20)
   )
 

--- a/tests/dune
+++ b/tests/dune
@@ -2,34 +2,32 @@
 (executable
   (name test_api)
   (libraries msat msat_sat)
-  (flags :standard -w +a-4-42-44-48-50-58-32-60@8 -color always -safe-string -open Msat)
-  (ocamlopt_flags :standard -O3 -color always
-                  -unbox-closures -unbox-closures-factor 20)
+  (flags -open Msat)
   )
 
-(alias
- (name    runtest)
+(rule
+ (alias    runtest)
   (package msat)
  (deps    test_api.exe)
  (locks test)
  (action  (run %{deps})))
 
-(alias
- (name    runtest)
+(rule
+ (alias    runtest)
   (package msat)
  (deps    ./icnf-solve/icnf_solve.exe Makefile (source_tree regression))
  (locks test)
  (action  (run make test-icnf)))
 
-(alias
- (name    runtest)
+(rule
+ (alias    runtest)
   (package msat)
  (deps    ./../src/sudoku/sudoku_solve.exe Makefile (source_tree sudoku))
  (locks test)
  (action  (run make test-sudoku)))
 
-(alias
-  (name runtest)
+(rule
+  (alias runtest)
   (package msat-bin)
   (deps   ./../src/main/main.exe ./run (source_tree .))
   (locks test)


### PR DESCRIPTION
Running `make` on the mSAT repository results in about a dozen of warnings. The present PR fixes all the warnings.

(I updated the dune language from 1.1 to 3.0. This is not strictly necessary but I had trouble with the dune syntax in places, I had to read the documentation again, and wanted to make sure that the behavior was consistent with the current-ish documentation.)