### PR TITLE
test(mdx): depend on `(package msat)`

### DIFF
--- a/dune
+++ b/dune
@@ -1,6 +1,7 @@
 (rule
  (alias runtest)
  (deps
+  (package msat)
   README.md
   src/core/msat.cma
   src/sat/msat_sat.cma


### PR DESCRIPTION
related:
- https://github.com/ocaml/dune/pull/14811
- https://github.com/c-cube/iter/pull/46